### PR TITLE
Stroke fix after outline group fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@main/script.js
 ```
 
 ```js
-https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.0/script.js
+https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.1/script.js
 ```
 
 ## Example usage
 
 ```js
-import { CanvasConverse } from "https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.0/script.js";
+import { CanvasConverse } from "https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.1/script.js";
 
 const $ = (x) => document.querySelector(x);
 
@@ -92,8 +92,8 @@ And much more in the [demo.js](https://github.com/hchiam/canvas-converse/blob/ma
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.0/script.js"
-  integrity="sha384-nieEOjEo3fgpVHX3FzJ6lchtNjexI+uzMtH25G+yF222HtSyXHrUFeopiWA8CJgj"
+  src="https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.1/script.js"
+  integrity="sha384-IYH/0FNYnJXcdoFKIq0bnP5aAC4t3glahdQzwciXH7L6zGDsiyr5LzOAKS5TreVL"
   crossorigin="anonymous"
 ></script>
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ And much more in the [demo.js](https://github.com/hchiam/canvas-converse/blob/ma
 ```html
 <script
   src="https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@3.2.1/script.js"
-  integrity="sha384-IYH/0FNYnJXcdoFKIq0bnP5aAC4t3glahdQzwciXH7L6zGDsiyr5LzOAKS5TreVL"
+  integrity="sha384-kiKnB+ACCxa4pebdryXnxqHZcO+K3lNDhDaVyGQ0jp0RO/DsyuCLLF0JvA6xCJOm"
   crossorigin="anonymous"
 ></script>
 ```

--- a/demo.js
+++ b/demo.js
@@ -18,6 +18,7 @@ const rotatingRectangle = cc.rectangle({
   h: 150,
   fill: "cyan",
   stroke: "red",
+  lineWidth: 10,
   rotationX: 300 + 150 / 2,
   rotationY: 50 + 150 / 2,
 });

--- a/documentation.md
+++ b/documentation.md
@@ -23,6 +23,7 @@ rectangle({
     rotationY /* y position of rotation */,
     fill,
     stroke,
+    lineWidth,
     physics,
     outlineGroup = "",
     addObject = true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-converse",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "script.js",
   "author": "hchiam",
   "description": "To more easily converse with the canvas API.",

--- a/script.js
+++ b/script.js
@@ -40,6 +40,7 @@ export class CanvasConverse {
     rotationY /* y position of rotation */,
     fill,
     stroke,
+    lineWidth,
     physics,
     outlineGroup = "",
     addObject = true,
@@ -66,7 +67,11 @@ export class CanvasConverse {
       }
       if (stroke && !usingOutlineGroup && !this.usingOutlineGroup) {
         this.context.strokeStyle = stroke ?? "transparent";
-        this.context.strokeRect(x, y, w, h);
+        if (lineWidth) {
+          this.context.lineWidth = lineWidth ?? 0;
+          this.context.strokeRect(x, y, w, h);
+          // this.context.stroke();
+        }
       }
     });
 
@@ -80,7 +85,8 @@ export class CanvasConverse {
         rotationX,
         rotationY,
         fill,
-        // stroke,
+        stroke,
+        lineWidth,
         physics,
         outlineGroup,
       });


### PR DESCRIPTION
i noticed `// stroke` in the code and uncommented it, and then had to fix a weird outline bug on the rotating square in the demo, and a fill bug in a falling triangle in the demo