### PR TITLE
reverting back to 4.1.0 to fix performance (cannot use outline groups easily with transparency for now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@main/script.js
 ```
 
 ```js
-https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.0/script.js
+https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.5/script.js
 ```
 
 ## Example usage
 
 ```js
-import { CanvasConverse } from "https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.0/script.js";
+import { CanvasConverse } from "https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.5/script.js";
 
 const $ = (x) => document.querySelector(x);
 
@@ -104,7 +104,7 @@ And much more in the [demo.js](https://github.com/hchiam/canvas-converse/blob/ma
 
 ```html
 <script
-  src="https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.0/script.js"
+  src="https://cdn.jsdelivr.net/gh/hchiam/canvas-converse@4.1.5/script.js"
   integrity="sha384-2EuqPs8+KJYuxfAVpgT5kHYoX/UydYjejKjabNQxxPf22iyBIYwWJdNMeRZKZeRZ"
   crossorigin="anonymous"
 ></script>

--- a/documentation.md
+++ b/documentation.md
@@ -1,6 +1,6 @@
 # CanvasConverse Documentation
 
-(Generated from generateDocumentation.js to clipboard - 2025/03/20th.)
+(Generated from generateDocumentation.js to clipboard - 2025/04/20th.)
 
 ## Methods
 
@@ -155,7 +155,7 @@ clear()
 
 # NaivePhysics Documentation
 
-(Generated from generateDocumentation.js to clipboard - 2025/03/20th.)
+(Generated from generateDocumentation.js to clipboard - 2025/04/20th.)
 
 ## Methods
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-converse",
-  "version": "4.1.0",
+  "version": "4.1.5",
   "main": "script.js",
   "types": "script.d.ts",
   "author": "hchiam",


### PR DESCRIPTION
# Problem/Need:

4.1.4 has memory performance problems with extra `CanvasConverse` objects being created for transparency to work with outline group

# Suggested changes:

just don't bother with transparency when using `makeOutlineGroup`, and revert back to 4.1.0